### PR TITLE
Fix the url and make target on make for K210

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ https://github.com/damien-lemoal/buildroot
 To build a Kendryte K210 boot image with kernel 5.8, do:
 
 ```
-> git clone git@github.com:damien-lemoal/buildroot.git
+> git clone https://github.com/damien-lemoal/buildroot
 > cd buildroot
-> make kendryte_k210_config
+> make kendryte_k210_defconfig
 > make
 ```
 


### PR DESCRIPTION
Update the make target for k210 to what is configured on https://github.com/damien-lemoal/buildroot